### PR TITLE
Fix async_trait path in Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ trait HelloWorld {
    fn hello(s: String) -> String;
 }
 struct HelloWorldApp;
-#[async_trait::async_trait]
+#[norpc::async_trait]
 impl HelloWorld for HelloWorldApp {
    async fn hello(&self, s: String) -> String {
        format!("Hello, {}", s)

--- a/norpc/src/lib.rs
+++ b/norpc/src/lib.rs
@@ -8,7 +8,7 @@
 //!    fn hello(s: String) -> String;
 //! }
 //! struct HelloWorldApp;
-//! #[async_trait::async_trait]
+//! #[norpc::async_trait]
 //! impl HelloWorld for HelloWorldApp {
 //!    async fn hello(&self, s: String) -> String {
 //!        format!("Hello, {}", s)


### PR DESCRIPTION
async_trait seems to come from norpc, not async_trait ^^

It's like this in example/async_std_runtime.rs